### PR TITLE
Add project: mkdocs-live-edit-plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1062,6 +1062,12 @@ projects:
   pypi_id: mkdocs-nav-weight
   labels: [plugin]
   category: nav-pages
+- name: mkdocs-live-edit-plugin
+  mkdocs_plugin: live-edit
+  github_id: eddyluten/mkdocs-live-edit-plugin
+  pypi_id: mkdocs-live-edit-plugin
+  labels: [plugin]
+  category: nav-pages
 
 - name: mkdocs-spellcheck
   mkdocs_plugin: spellcheck


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

I created this plugin to allow MkDocs users to edit their pages directly from the browser while running wiki locally via `mkdocs serve`. It cuts back quite a bit on alt+tabbing and then looking for the file you're viewing in the browser. I've added a little video to the project's [GitHub page](https://github.com/EddyLuten/mkdocs-live-edit-plugin) to show how it works.

Thanks for MkDocs and this list as well!

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
