### PR TITLE
Add project: mkdocs-open-in-new-tab

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -855,6 +855,12 @@ projects:
   pypi_id: mkdocs-link-marker
   labels: [plugin]
   category: links-refs
+- name: mkdocs-open-in-new-tab
+  mkdocs_plugin: open-in-new-tab
+  github_id: JakubAndrysek/mkdocs-open-in-new-tab
+  pypi_id: mkdocs-open-in-new-tab
+  labels: [plugin]
+  category: links-refs
 
 - name: markdown-callouts
   markdown_extension: callouts


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
This plugin adds JS code to open outgoing links and PDFs in a new tab.

The automatic opening of links in a new tab is a common feature of modern websites. It is also a good practice for accessibility. However, it is not a default behavior of Markdown. This plugin adds a JavaScript code to your website that opens external links and PDFs in a new tab.
[Demo](https://newtab.kubaandrysek.cz/)



- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
