### PR TITLE
add mkdocs-addresses plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -828,6 +828,7 @@ projects:
   labels: [plugin]
   category: links-refs
 - name: Mkdocs-Addresses
+  mkdocs_plugin: mkdocs-addresses
   gitlab_id: frederic.zinelli/mkdocs-addresses
   pypi_id: mkdocs-addresses
   labels: [plugin]

--- a/projects.yaml
+++ b/projects.yaml
@@ -827,6 +827,11 @@ projects:
   pypi_id: mkdocs-webcontext-plugin
   labels: [plugin]
   category: links-refs
+- name: Mkdocs-Addresses
+  gitlab_id: frederic.zinelli/mkdocs-addresses
+  pypi_id: mkdocs-addresses
+  labels: [plugin]
+  category: links-refs
 - name: emailprotect
   mkdocs_plugin: emailprotect
   github_id: rkoe/mkdocs-emailprotect


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Add a new [plugin for mkdocs I created](https://gitlab.com/frederic.zinelli/mkdocs-addresses).  

I didn't know if the order matters... I put the information just in between the last shown project in the `links-refs` section and the "drop down" section. I hope this is fine.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
