### PR TITLE
Remove offline plugin for Material for MkDocs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -63,7 +63,7 @@ labels:
 projects:
 - name: Material for MkDocs
   mkdocs_theme: material
-  mkdocs_plugin: [material/offline, material/search, material/social, material/tags]
+  mkdocs_plugin: [material/search, material/social, material/tags]
   github_id: squidfunk/mkdocs-material
   pypi_id: mkdocs-material
   labels: [theme, plugin]


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Add a project
- [x] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [x] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

We've encountered multiple issues where users used the [offline](https://squidfunk.github.io/mkdocs-material/plugins/offline/) plugin in online contexts, so we had to tell them to turn it off and only use it when bundling your documentation for distribution and download, which [our documentation clearly explains](https://squidfunk.github.io/mkdocs-material/plugins/offline/#when-to-use-it). I suspect that the catalog might be one of the sources where they copy the configuration from. It makes no sense to use the [offline](https://squidfunk.github.io/mkdocs-material/plugins/offline/) plugin when building online documentation, which the majority of users is doing.

This PR removes it from the recommended configuration. Closes #99

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
