### PR TITLE
Dispatch 'others' into existing categories

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -43,8 +43,6 @@ categories:
   title: 🔧 Site management
 - category: snippets-include
   title: 📁 Snippets & includes (reusing contents)
-- category: other
-  title: 👽 Other
 
 labels:
 - label: plugin
@@ -529,6 +527,28 @@ projects:
   pypi_id: mkdocs-plugin-inline-svg-mod
   labels: [plugin]
   category: charts
+- name: Family tree example
+  github_id: unverbuggt/mkdocs-familytree-example
+  labels: []
+  category: charts
+- name: pico-8
+  mkdocs_plugin: pico-8
+  github_id: fmaida/pico8-mkdocs-plugin
+  pypi_id: pico8-mkdocs-plugin
+  labels: [plugin]
+  category: charts
+- name: thumbnails
+  mkdocs_plugin: thumbnails
+  github_id: normanlorrain/mkdocs-thumbnails
+  pypi_id: mkdocs-thumbnails
+  labels: [plugin]
+  category: charts
+- name: badges
+  mkdocs_plugin: badges
+  github_id: six-two/mkdocs-badges
+  pypi_id: mkdocs-badges
+  labels: [plugin]
+  category: charts
 
 - name: pheasant
   mkdocs_plugin: pheasant
@@ -642,6 +662,12 @@ projects:
   mkdocs_plugin: termynal
   github_id: mkdocs-plugins/termynal
   pypi_id: termynal
+  labels: [plugin]
+  category: code-exec-templating
+- name: placeholder
+  mkdocs_plugin: placeholder
+  github_id: six-two/mkdocs-placeholder-plugin
+  pypi_id: mkdocs-placeholder-plugin
   labels: [plugin]
   category: code-exec-templating
 
@@ -949,6 +975,13 @@ projects:
   github_id: OctoPrint/mkdocs-site-urls
   pypi_id: mkdocs-site-urls
   labels: [plugin]
+  category: links-refs
+- name: bibtex
+  mkdocs_plugin: bibtex
+  github_id: shyamd/mkdocs-bibtex
+  pypi_id: mkdocs-bibtex
+  labels: [plugin]
+  license: BSD-3-Clause-LBNL
   category: links-refs
 
 - name: markdown-callouts
@@ -1264,6 +1297,12 @@ projects:
   pypi_id: mkdocs-pagetree-plugin
   labels: [plugin]
   category: nav-pages
+- name: vim-md-tags
+  mkdocs_plugin: vim-md-tags
+  github_id: midnightprioriem/mkdocs-vim-md-tags-plugin
+  pypi_id: mkdocs-vim-md-tags-plugin
+  labels: [plugin]
+  category: nav-pages
 
 - name: mkdocs-spellcheck
   mkdocs_plugin: spellcheck
@@ -1473,6 +1512,24 @@ projects:
   pypi_id: mkdocs-exclude-tagged-files
   labels: [plugin]
   category: site-management
+- name: no-sitemap
+  mkdocs_plugin: no-sitemap
+  github_id: leonardehrenfried/mkdocs-no-sitemap-plugin
+  pypi_id: mkdocs-no-sitemap-plugin
+  labels: [plugin]
+  category: site-management
+- name: techdocs-core
+  mkdocs_plugin: techdocs-core
+  github_id: backstage/mkdocs-techdocs-core
+  pypi_id: mkdocs-techdocs-core
+  labels: [plugin]
+  category: site-management
+- name: same-dir
+  mkdocs_plugin: same-dir
+  github_id: oprypin/mkdocs-same-dir
+  pypi_id: mkdocs-same-dir
+  labels: [plugin]
+  category: site-management
 
 - name: mkdocs-embed-external-markdown
   mkdocs_plugin: external-markdown
@@ -1530,63 +1587,3 @@ projects:
   pypi_id: mkdocs-version-annotations
   labels: [plugin]
   category: snippets-include
-
-- name: bibtex
-  mkdocs_plugin: bibtex
-  github_id: shyamd/mkdocs-bibtex
-  pypi_id: mkdocs-bibtex
-  labels: [plugin]
-  license: BSD-3-Clause-LBNL
-  category: other
-- name: pico-8
-  mkdocs_plugin: pico-8
-  github_id: fmaida/pico8-mkdocs-plugin
-  pypi_id: pico8-mkdocs-plugin
-  labels: [plugin]
-  category: other
-- name: same-dir
-  mkdocs_plugin: same-dir
-  github_id: oprypin/mkdocs-same-dir
-  pypi_id: mkdocs-same-dir
-  labels: [plugin]
-  category: other
-- name: thumbnails
-  mkdocs_plugin: thumbnails
-  github_id: normanlorrain/mkdocs-thumbnails
-  pypi_id: mkdocs-thumbnails
-  labels: [plugin]
-  category: other
-- name: vim-md-tags
-  mkdocs_plugin: vim-md-tags
-  github_id: midnightprioriem/mkdocs-vim-md-tags-plugin
-  pypi_id: mkdocs-vim-md-tags-plugin
-  labels: [plugin]
-  category: other
-- name: badges
-  mkdocs_plugin: badges
-  github_id: six-two/mkdocs-badges
-  pypi_id: mkdocs-badges
-  labels: [plugin]
-  category: other
-- name: placeholder
-  mkdocs_plugin: placeholder
-  github_id: six-two/mkdocs-placeholder-plugin
-  pypi_id: mkdocs-placeholder-plugin
-  labels: [plugin]
-  category: other
-- name: no-sitemap
-  mkdocs_plugin: no-sitemap
-  github_id: leonardehrenfried/mkdocs-no-sitemap-plugin
-  pypi_id: mkdocs-no-sitemap-plugin
-  labels: [plugin]
-  category: other
-- name: techdocs-core
-  mkdocs_plugin: techdocs-core
-  github_id: backstage/mkdocs-techdocs-core
-  pypi_id: mkdocs-techdocs-core
-  labels: [plugin]
-  category: other
-- name: Family tree example
-  github_id: unverbuggt/mkdocs-familytree-example
-  labels: []
-  category: other


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Add a project
- [ ] Update a project
- [ ] Remove a project
- [x] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Dispatch projects from "Other" category into existing categories. This wasn't fair to relay them to this "Other" category, and I think they match the existing categories well.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
