### PR TITLE
Add project: mkdocs-required-frontmatter-plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1541,7 +1541,12 @@ projects:
   pypi_id: mkdocs-same-dir
   labels: [plugin]
   category: site-management
-
+- name: mkdocs-required-frontmatter-plugin
+  mkdocs_plugin: required-frontmatter
+  github_id: unmc-vcr/mkdocs-required-frontmatter-plugin
+  pypi_id:  mkdocs-required-frontmatter-plugin
+  labels: [plugin]
+  category: site-management
 - name: mkdocs-embed-external-markdown
   mkdocs_plugin: external-markdown
   github_id: fire1ce/mkdocs-embed-external-markdown

--- a/projects.yaml
+++ b/projects.yaml
@@ -1547,6 +1547,7 @@ projects:
   pypi_id:  mkdocs-required-frontmatter-plugin
   labels: [plugin]
   category: site-management
+
 - name: mkdocs-embed-external-markdown
   mkdocs_plugin: external-markdown
   github_id: fire1ce/mkdocs-embed-external-markdown


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [X] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes. We recommend only to add, update, or remove one project per pull request. If your PR adds a new project, just put the project name and a short description of the project here.-->

This PR adds the project mkdocs-required-frontmatter-plugin.  This plugin adds a hook on generation that enforces required YAML front matter for all documentation.  This can be helpful to enforce consistency across project maintainers or when build processes (particularly those outside MkDocs) further process documentation.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [X] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [X] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
