### PR TITLE
Add projects, use smaller label images

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -824,6 +824,11 @@ projects:
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: html-css
+- name: MkDocs Pygments
+  mkdocs_plugin: pygments
+  github_id: pawamoy/mkdocs-pygments
+  labels: [plugin]
+  category: html-css
 
 - name: static-i18n
   mkdocs_plugin: i18n
@@ -1178,6 +1183,11 @@ projects:
 - name: caption
   markdown_extension: [caption, image_captions, table_captions]
   github_id: flywire/caption
+  labels: [markdown]
+  category: markdown
+- name: Markdown PyCon
+  markdown_extension: pycon
+  github_id: pawamoy/markdown-pycon
   labels: [markdown]
   category: markdown
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -49,16 +49,16 @@ categories:
 
 labels:
 - label: plugin
-  image: https://cdn.icon-icons.com/icons2/1465/PNG/512/701electricplug_100845.png
+  image: https://cdn.icon-icons.com/icons2/1465/PNG/32/701electricplug_100845.png
   description: MkDocs plugin
 - label: theme
-  image: https://cdn.icon-icons.com/icons2/1495/PNG/512/preferencesdesktoptheme_102980.png
+  image: https://cdn.icon-icons.com/icons2/1495/PNG/32/preferencesdesktoptheme_102980.png
   description: MkDocs theme
 - label: project
-  image: https://cdn.icon-icons.com/icons2/1448/PNG/512/42498factory_99134.png
+  image: https://cdn.icon-icons.com/icons2/1448/PNG/32/42498factory_99134.png
   description: Mkdocs-based project (website, templates, etc.)
 - label: markdown
-  image: https://cdn.icon-icons.com/icons2/1459/PNG/512/2799201-jigsaw-processing_99781.png
+  image: https://cdn.icon-icons.com/icons2/1459/PNG/32/2799201-jigsaw-processing_99781.png
   description: Markdown extension(s)
 
 projects:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [x] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Add two of my projects, use smaller images for labels (no need to download bigger ones).

**Outdated description:**

"Sponsorware" label added. ~~Not sure if this is the best word ("commercial") to describe the projects I added. I might change it to "Sponsorware" directly since this is the only type of "paid" projects I know in the MkDocs ecosystem.~~

Also not sure about the image for the label: currently it's a dollar bill. I don't think it does justice to the sponsorware model, but I can't find any other relevant icon. Maybe something more like an ["exchange"](https://icon-icons.com/icon/direction-left-right-arrows-exchange-transfer/258782)? Or a red heart :heart: :man_shrugging:? [A heart and a lock](https://icon-icons.com/search/icons/?filtro=heart+lock&sort=popular)? 

Note: I'm also OK to just list such projects without a particular label :shrug: 

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
