### PR TITLE
Add plugin: mkdocs-auto-refresh-build-pages

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1630,6 +1630,12 @@ projects:
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: site-management
+- name: mkdocs-auto-refresh-build-pages
+  mkdocs_plugin: auto-refresh-build-pages
+  github_id: JakubAndrysek/mkdocs-auto-refresh-build-pages
+  pypi_id: mkdocs-auto-refresh-build-pages
+  labels: [plugin]
+  category: site-management
 
 - name: ansible-document
   homepage: https://pypi.org/project/ansible-mkdocs/


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
 Add plugin: mkdocs-auto-refresh-build-pages

MkDocs plugin that automatically refreshes the build pages when the documentation is updated.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
