### PR TITLE
Update of MkDocs Publisher plugins related to project repo migration

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -379,6 +379,7 @@ projects:
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: blogging
+
 - name: table-reader
   mkdocs_plugin: table-reader
   github_id: timvink/mkdocs-table-reader-plugin

--- a/projects.yaml
+++ b/projects.yaml
@@ -374,12 +374,11 @@ projects:
   category: blogging
 - name: Publisher for MkDocs - blog
   mkdocs_plugin: pub-blog
-  description: Blogging engine
-  github_id: mkusz/mkdocs-publisher
+  description: Blogging engine with support for categories, tags and archive
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: blogging
-
 - name: table-reader
   mkdocs_plugin: table-reader
   github_id: timvink/mkdocs-table-reader-plugin
@@ -841,14 +840,14 @@ projects:
 - name: Publisher for MkDocs - social
   mkdocs_plugin: pub-social
   description: Social media sharing helper
-  github_id: mkusz/mkdocs-publisher
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: html-css
 - name: Publisher for MkDocs - minifier
   mkdocs_plugin: pub-minifier
-  description: HTML, CSS and graphics files size optimization
-  github_id: mkusz/mkdocs-publisher
+  description: Size optimization (minification) for HTML, CSS, JS, SVG, PNG and JPEG files
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: html-css
@@ -920,8 +919,8 @@ projects:
   category: integrations
 - name: Publisher for MkDocs - obsidian
   mkdocs_plugin: pub-obsidian
-  description: Obsidian.md integration including with support for wiki links, callouts, etc.
-  github_id: mkusz/mkdocs-publisher
+  description: Obsidian.md integration including with support for wiki links, callouts, backlinks etc.
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: integrations
@@ -1386,8 +1385,8 @@ projects:
   category: nav-pages
 - name: Publisher for MkDocs - meta
   mkdocs_plugin: pub-meta
-  description: Navigation and page building based on files metadata
-  github_id: mkusz/mkdocs-publisher
+  description: Automatic navigation based on files metadata with URL name and publication status control
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: nav-pages
@@ -1632,7 +1631,7 @@ projects:
 - name: Publisher for MkDocs - debugger
   mkdocs_plugin: pub-debugger
   description: Advanced console and file logger from build and serve process
-  github_id: mkusz/mkdocs-publisher
+  github_id: mkdocs-publisher/mkdocs-publisher
   pypi_id: mkdocs-publisher
   labels: [plugin]
   category: site-management


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Add a project
- [x] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Update of `gihthub_id` due to project migration to the other repository in a separate GitHub organization related just to MkDocs Publisher. Moreover, I have made some description updates.

**Checklist:**
- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
