### PR TITLE
Remove completely nonfunctional and misleading plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1348,12 +1348,6 @@ projects:
   pypi_id: mkdocs-gallery
   labels: [plugin]
   category: nav-pages
-- name: mkdocs-copy
-  mkdocs_plugin: copy
-  github_id: chikamichi/mkdocs-copy
-  pypi_id: mkdocs-copy
-  labels: [plugin]
-  category: nav-pages
 - name: file-filter
   mkdocs_plugin: file-filter
   github_id: DariuszPorowski/mkdocs-file-filter-plugin


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Add a project
- [ ] Update a project
- [x] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

This plugin was added as part of a bulk operation (https://github.com/mkdocs/catalog/commit/f0901f271000dc3d0c47a9ca1e3c1a2e0750f83a), evidently without the least vetting.

The plugin author never made an effort to make the plugin do what it claims to do; adding arbitrary additional external source files to the website:

https://github.com/chikamichi/mkdocs-copy#copy-files-in-your-mkdocs-build

> mkdocs-copy is a plugin for [MkDocs](https://www.mkdocs.org/) which allows you to copy verbatim arbitrary files in your build.

They instead simply implementing the copying of the specific file (`.htaccess`) they needed for their own application:

https://github.com/chikamichi/mkdocs-copy/blob/c7d3306cd85e4b0119e8a21cf1c47f972b220fc1/mkdocs_copy/__init__.py#L42-L47

```python
source_file = os.path.join(source_dir, '.htaccess')
exists_dest_file = os.path.isfile(source_file)
logging.debug('source file: ' + source_file +
              ' (exists: ' + str(exists_dest_file) + ')')

exists_dest_file and utils.copy_file(source_file, dest_dir)
```

The plugin author is aware of this deficiency and tracking it in a vaguely worded issue report in the repository (https://github.com/chikamichi/mkdocs-copy/issues/1), but that issue has been open for over 2.5 years without any effort to actually implement the promised functionality.

The description in the catalog and in the plugin documentation claim the plugin provides the arbitrary file copying capability, and don't make any mention that it doesn't actually do that. Worse, [the demonstration MkDocs configuration file snippet](https://github.com/chikamichi/mkdocs-copy#quick-start) in the plugin's documentation appears to configure the plugin to copy a `.htaccess` file, which would lead the reader who followed the demo as written when evaluating the plugin to think it provided the promised arbitrary file copying functionality until such time as they tried to use the plugin in their own application. The only way they could discover why it stopped working would be to study the plugin's source code or find and correctly interpret the vague issue report in the GitHub repository.

So clearly the plugin is objectively not qualified for inclusion in the catalog and must be removed out of respect for the catalog users.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
