### PR TITLE
add project: mkdocs_quiz

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1673,7 +1673,7 @@ projects:
   pypi_id: mkdocs-auto-refresh-build-pages
   labels: [plugin]
   category: site-management
-- name: Mkdocs Quiz
+- name: Mkdocs Quizz
   mkdocs_plugin: mkdocs_quizz
   pypi_id: mkdocs-quizz
   github_id: bdallard/mkdocs_quiz

--- a/projects.yaml
+++ b/projects.yaml
@@ -1250,6 +1250,14 @@ projects:
   license: ISC
   labels: [markdown]
   category: markdown
+- name: Mkdocs Quiz
+  markdown_extension: mkdocs_quizz
+  pypi_id: mkdocs-quizz
+  github_id: bdallard/mkdocs_quiz
+  license: MIT
+  labels: [markdown]
+  category: markdown
+
 
 - name: exclude
   mkdocs_plugin: exclude

--- a/projects.yaml
+++ b/projects.yaml
@@ -1251,7 +1251,6 @@ projects:
   labels: [markdown]
   category: markdown
 
-
 - name: exclude
   mkdocs_plugin: exclude
   github_id: apenwarr/mkdocs-exclude

--- a/projects.yaml
+++ b/projects.yaml
@@ -1681,7 +1681,6 @@ projects:
   labels: [plugin]
   category: site-management
 
-
 - name: ansible-document
   homepage: https://pypi.org/project/ansible-mkdocs/
   description: Auto-generate ansible role documentation

--- a/projects.yaml
+++ b/projects.yaml
@@ -1250,13 +1250,6 @@ projects:
   license: ISC
   labels: [markdown]
   category: markdown
-- name: Mkdocs Quiz
-  markdown_extension: mkdocs_quizz
-  pypi_id: mkdocs-quizz
-  github_id: bdallard/mkdocs_quiz
-  license: MIT
-  labels: [markdown]
-  category: markdown
 
 
 - name: exclude
@@ -1680,6 +1673,14 @@ projects:
   pypi_id: mkdocs-auto-refresh-build-pages
   labels: [plugin]
   category: site-management
+- name: Mkdocs Quiz
+  mkdocs_plugin: mkdocs_quizz
+  pypi_id: mkdocs-quizz
+  github_id: bdallard/mkdocs_quiz
+  license: MIT
+  labels: [plugin]
+  category: site-management
+
 
 - name: ansible-document
   homepage: https://pypi.org/project/ansible-mkdocs/


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [X] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
mkdocs_quiz is a MkDocs plugin that allows you to integrate interactive quizzes into your documentation site using custom JSON files and supports multiple quiz types.

**Checklist:**

- [X] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [X] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
