### PR TITLE
add new plugin: mkdocs-document-dates

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -775,6 +775,12 @@ projects:
   license: MIT
   category: code-exec-templating
 
+- name: document-dates
+  mkdocs_plugin: document-dates
+  github_id: jaywhj/mkdocs-document-dates
+  pypi_id: mkdocs-document-dates
+  labels: [plugin]
+  category: git-info
 - name: branchcustomization
   mkdocs_plugin: branchcustomization
   github_id: effigies/mkdocs-branchcustomization-plugin


### PR DESCRIPTION
add new plugin - mkdocs-document-dates

**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
For displaying **accurate** document creation and last modification dates, No Git dependency.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
