### PR TITLE
Add heroshot - screenshot automation for docs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -627,6 +627,12 @@ projects:
   pypi_id: mkdocs-image-formatter-plugin
   labels: [plugin]
   category: charts
+- name: Heroshot
+  description: Screenshot automation for documentation. Capture once, regenerate forever. Theme-aware macro for light/dark mode with responsive viewports.
+  github_id: omachala/heroshot
+  pypi_id: heroshot
+  labels: []
+  category: charts
 - name: inline-svg
   mkdocs_plugin: inline-svg
   github_id: rajguru7/mkdocs-plugin-inline-svg-mod


### PR DESCRIPTION
Adds [heroshot](https://github.com/omachala/heroshot) to the catalog.

**What it does:**
- Screenshot automation CLI - define screenshots once, regenerate with one command
- MkDocs macro for theme-aware screenshots (light/dark mode switches automatically)
- Responsive viewport support (desktop, tablet, mobile)

**PyPI:** https://pypi.org/project/heroshot/
**Docs:** https://heroshot.sh