### PR TITLE
Add mkdocs-zen-mode plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -963,6 +963,13 @@ projects:
   pypi_id: mkdocs-toggle-sidebar-plugin
   labels: [plugin]
   category: html-css
+- name: zen-mode
+  mkdocs_plugin: zen-mode
+  description: Zen Mode toggle for distraction-free reading — hides navigation, TOC, header, footer with a single click or keyboard shortcut
+  github_id: nitaibezerra/mkdocs-zen-mode
+  pypi_id: mkdocs-zen-mode
+  labels: [plugin]
+  category: html-css
 - name: mkdocs-extra-sass-plugin
   mkdocs_plugin: extra-sass
   github_id: orzih/mkdocs-extra-sass-plugin


### PR DESCRIPTION
## New Project

- **Name**: mkdocs-zen-mode
- **Plugin name**: `zen-mode`
- **Category**: html-css
- **GitHub**: https://github.com/nitaibezerra/mkdocs-zen-mode
- **PyPI**: https://pypi.org/project/mkdocs-zen-mode/

## Description

Zen Mode toggle for MkDocs Material — distraction-free reading. Adds a toggle button to the header that hides navigation, TOC, header, footer, and tabs with a single click or keyboard shortcut (Alt+Z). State persists via localStorage across pages and sessions.

### Features
- Toggle button in header (next to search)
- Configurable: choose which elements to hide
- Keyboard shortcut (Alt+Z, configurable)
- localStorage persistence
- Works with `navigation.instant` (SPA mode)
- Smooth CSS transitions
- Floating exit button
- Dark mode compatible
- 68 tests (unit + integration + Playwright E2E)

### Installation
```bash
pip install mkdocs-zen-mode
```

```yaml
plugins:
  - zen-mode
```