### PR TITLE
Add project: mkdocs-repo-docs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -175,7 +175,7 @@ projects:
   labels: [theme]
   category: theming
 - name: Zettelkasten
-  mkdocs_theme: zettelkasten-solarized-light
+  mkdocs_theme: zettelkasten
   mkdocs_plugin: [zettelkasten]
   github_id: buvis/mkdocs-zettelkasten
   pypi_id: mkdocs-zettelkasten

--- a/projects.yaml
+++ b/projects.yaml
@@ -1601,6 +1601,12 @@ projects:
   pypi_id: mkdocs-authors-plugin
   labels: [plugin]
   category: nav-pages
+- name: repo-docs
+  mkdocs_plugin: repo-docs
+  github_id: killrazor/mkdocs-repo-docs
+  pypi_id: mkdocs-repo-docs
+  labels: [plugin]
+  category: nav-pages
 
 - name: mkdocs-spellcheck
   mkdocs_plugin: spellcheck


### PR DESCRIPTION
Adds [mkdocs-repo-docs](https://github.com/killrazor/mkdocs-repo-docs) to the nav-pages category.

**What it does:** Auto-discovers markdown files scattered throughout a repository (README files next to code, docs in component directories, files in dotfile directories like .github/) and includes them in the MkDocs documentation site.

**Key features:**
- Stages repo files into docs/_repo/ at build time
- Handles dotfile directories that MkDocs normally excludes
- Directory and file renaming for clean nav
- Footer injection with source path links
- Configurable nav section positioning
- Live reload for local development

**PyPI:** https://pypi.org/project/mkdocs-repo-docs/
**GitHub:** https://github.com/killrazor/mkdocs-repo-docs
**License:** MIT

---

Also fixes the Zettelkasten theme entry point name (zettelkasten-solarized-light to zettelkasten) which has been causing check_projects.py to fail.

## Checklist:

- [x] I have read the CONTRIBUTING guidelines.
- [x] I have not modified the README.md file. Projects are only supposed to be added or updated within the projects.yaml file since the README.md file is automatically generated.