### PR TITLE
Fix typo in project name for GitHub Release Changelog

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -903,7 +903,7 @@ projects:
   pypi_id: mkdocs-git-latest-changes-plugin
   labels: [plugin]
   category: git-info
-- name: Github Releaase Changelog
+- name: Github Release Changelog
   mkdocs_plugin: mkdocs_github_changelog
   github_id: djpugh/mkdocs_github_changelog
   pypi_id: mkdocs-github-changelog


### PR DESCRIPTION
fix typo (Releaase -> Release)

**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [X] Documentation
- [ ] Other, please describe:

**Description:**
Fix small typo.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
