### PR TITLE
Add mkdocs-adr-plugin to catalog

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -759,7 +759,7 @@ projects:
   github_id: textileio/mkdocs-codeyaml-plugin
   pypi_id: mkdocs-codeyaml-plugin
   labels: [plugin]
-  license: MIT
+  license: MIT  
   category: code-exec-templating
 - name: markdown-filter
   mkdocs_plugin: markdown-filter
@@ -1928,3 +1928,10 @@ projects:
   pypi_id: markdown-version-annotations
   labels: [markdown]
   category: snippets-include
+- name: mkdocs-adr-plugin
+  mkdocs_plugin: adr_plugin
+  github_id: maresin/mkdocs-adr-plugin
+  pypi_id: mkdocs-adr-plugin
+  labels: [plugin]
+  license: MIT
+  category: code-exec-templating 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Add `mkdocs-adr-plugin` – a plugin for MkDocs that adds a floating button to create Architecture Decision Records (ADR) directly from the documentation UI. It includes a modal form with template selection, live editing, automatic numbering, and date substitution. The plugin also provides a CLI wrapper `mkdocs-adr` that starts both the API backend (FastAPI) and `mkdocs serve` in one terminal.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.