### PR TITLE
Set commit author to GitHub bot

### DIFF
--- a/.github/workflows/update-best-of-list.yml
+++ b/.github/workflows/update-best-of-list.yml
@@ -51,6 +51,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: ${{ env.BRANCH_PREFIX }}${{ env.VERSION  }}
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           commit_user_name: best-of update
           commit_user_email: actions@github.com
           commit_message: Update best-of list for version ${{ env.VERSION  }}


### PR DESCRIPTION
For some reason, the scheduled run still implicitly sets my own account as commit author. I'm not working on this anymore and would like this link removed.