### PR TITLE
Add MkDocs Source Links

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1928,3 +1928,10 @@ projects:
   pypi_id: markdown-version-annotations
   labels: [markdown]
   category: snippets-include
+- name: MkDocs Source Links
+  mkdocs_plugin: source-links
+  github_id: filipchristiansen/mkdocs-source-links
+  pypi_id: mkdocs-source-links
+  license: MIT
+  labels: [plugin]
+  category: links-refs


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds **MkDocs Source Links** (`pypi: mkdocs-source-links`, plugin name `source-links`, category `links-refs`).

MkDocs plugin that rewrites parent-directory (`](../path)`) markdown links to your git forge's view URLs in the built HTML only. Source markdown keeps working relative paths (so links still resolve on the forge and in your IDE); files become `blob` URLs and directories `tree` URLs, with the branch resolved from config / `edit_uri`. Supports GitHub (incl. Enterprise), GitLab, Bitbucket, Gitea/Forgejo (incl. Codeberg), and Azure DevOps, with host autodetection and an explicit `forge` override. Docs: https://filipchristiansen.github.io/mkdocs-source-links/

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.