### PR TITLE
Add project: mkdocs-biel

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1928,3 +1928,9 @@ projects:
   pypi_id: markdown-version-annotations
   labels: [markdown]
   category: snippets-include
+- name: mkdocs-biel
+  mkdocs_plugin: biel
+  github_id: TechDocsStudio/mkdocs-biel
+  pypi_id: mkdocs-biel
+  labels: [plugin]
+  category: search-toc


### PR DESCRIPTION
Adds [mkdocs-biel](https://github.com/TechDocsStudio/mkdocs-biel), a plugin that embeds an Ask AI chatbot answering questions from your documentation, with citations to the source pages. 

Works with any theme, including Material for MkDocs. MIT licensed, published on PyPI as [`mkdocs-biel`](https://pypi.org/project/mkdocs-biel/). 

Categorized under `search-toc` alongside the other search projects.