### PR TITLE
Add mkdocs-rangefind

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1644,6 +1644,12 @@ projects:
   pypi_id: mkdocs-task-collector
   labels: [plugin]
   category: search-toc
+- name: mkdocs-rangefind
+  mkdocs_plugin: rangefind
+  github_id: xjodoin/rangefind
+  pypi_id: mkdocs-rangefind
+  labels: [plugin]
+  category: search-toc
 - name: localsearch
   mkdocs_plugin: localsearch
   github_id: wilhelmer/mkdocs-localsearch


### PR DESCRIPTION
Adds **mkdocs-rangefind** to Search & tables of content.

The plugin runs after `mkdocs build`, indexes the built site into a [rangefind](https://rangefind.dev) static search index (BM25F relevance, typo correction, search-as-you-type), and injects an accessible search widget — no search server, the browser queries the index with HTTP range requests.

- PyPI: https://pypi.org/project/mkdocs-rangefind/
- Source: https://github.com/xjodoin/rangefind/tree/main/integrations/mkdocs-rangefind (monorepo)
- Docs: https://rangefind.dev/docs/plugins/