### PR TITLE
Add mkdocs-agentready plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1106,6 +1106,13 @@ projects:
   pypi_id: mkdocs-copy-to-llm
   labels: [plugin]
   category: integrations
+- name: mkdocs-agentready
+  mkdocs_plugin: agentready
+  github_id: AshutoshRaj97/agentready-mcp
+  pypi_id: mkdocs-agentready
+  labels: [plugin]
+  license: MIT
+  category: integrations
 
 - name: Autolink References
   mkdocs_plugin: autolink_references


### PR DESCRIPTION
## Summary

Adds [mkdocs-agentready](https://pypi.org/project/mkdocs-agentready/) to the catalog.

**Plugin:** `agentready`
**PyPI:** https://pypi.org/project/mkdocs-agentready/
**GitHub:** https://github.com/AshutoshRaj97/agentready-mcp

After each `mkdocs build` or `mkdocs gh-deploy`, this plugin submits your docs site to [AgentReady](https://www.agentready.it.com) — a hosted MCP server that crawls your docs and makes them instantly queryable by AI agents (Claude, Cursor, Windsurf, and any MCP client) with cited, multi-page answers.

## Checklist

- [x] Plugin published on PyPI
- [x] MIT license
- [x] Entry follows existing YAML format
- [x] Category: `integrations`