### PR TITLE
Add project: mkdocs-unirate

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -713,6 +713,12 @@ projects:
   pypi_id: mkdocs-markdownextradata-plugin
   labels: [plugin]
   category: code-exec-templating
+- name: mkdocs-unirate
+  mkdocs_plugin: unirate
+  github_id: UniRate-API/mkdocs-unirate
+  pypi_id: mkdocs-unirate
+  labels: [plugin]
+  category: code-exec-templating
 - name: jinja2sandbox
   mkdocs_plugin: jinja2sandbox
   github_id: rkoe/mkdocs-jinja2sandbox


### PR DESCRIPTION
Adds **mkdocs-unirate** to the `code-exec-templating` category (variables & templating).

[mkdocs-unirate](https://github.com/UniRate-API/mkdocs-unirate) is an MkDocs plugin that injects live [UniRate](https://unirateapi.com) currency exchange rates into docs **at build time**, alongside plugins like `macros` and `markdownextradata`:

- Inline Markdown placeholders: `{{ unirate_rate:USD:EUR }}` and `{{ unirate_convert:USD:EUR:100 }}`
- A Jinja `unirate` global for themes/templates (`{{ unirate.rate('USD','EUR') }}`, `{{ unirate.currencies }}`)
- `strict` mode aborts the build on failure; non-strict logs a warning and leaves the placeholder in place
- Runtime dependencies: `mkdocs` + `requests` only

Entry added to `projects.yaml` (never the README, per the contribution guidelines):

```yaml
- name: mkdocs-unirate
  mkdocs_plugin: unirate
  github_id: UniRate-API/mkdocs-unirate
  pypi_id: mkdocs-unirate
  labels: [plugin]
  category: code-exec-templating
```

GitHub: https://github.com/UniRate-API/mkdocs-unirate · PyPI: `mkdocs-unirate` (MIT).