### PR TITLE
Add project: NeoAbs

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -258,6 +258,13 @@ projects:
   labels: [theme, plugin]
   category: theming
 
+- name: NeoAbs
+  mkdocs_theme: neoabs
+  github_id: rkriad585/mkdocs-neoabs
+  pypi_id: mkdocs-neoabs
+  labels: [theme]
+  category: theming
+
 - name: automacdoc
   github_id: AlexandreKempf/automacdoc
   pypi_id: automacdoc


### PR DESCRIPTION
## Add project: NeoAbs

**NeoAbs** — Apple Liquid Glass + NothingOS design language for MkDocs.

### Links
- GitHub: https://github.com/rkriad585/mkdocs-neoabs
- PyPI: https://pypi.org/project/mkdocs-neoabs/
- Documentation: https://rkriad585.github.io/mkdocs-neoabs

### Description
A modern MkDocs theme combining Apple's Liquid Glass aesthetics (backdrop-filter blur, depth layers, glassmorphism) with NothingOS design principles (pure black backgrounds, monochrome palette, Nothing Red accent). Features Space Grotesk + Space Mono typography, full dark/light mode, responsive layout, and search integration.

### Theme entry
```yaml
- name: NeoAbs
  mkdocs_theme: neoabs
  github_id: rkriad585/mkdocs-neoabs
  pypi_id: mkdocs-neoabs
  labels: [theme]
  category: theming
```
